### PR TITLE
fix amr2joint config name typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Current available parsers are
 | [(Drozdov et al 2022)](https://arxiv.org/abs/2205.01464) MAP    | amr2.0-structured-bart-large-neur-al-seed42            |   10    |   84.0  |
 | [(Drozdov et al 2022)](https://arxiv.org/abs/2205.01464) MAP    | amr3.0-structured-bart-large-neur-al-seed42            |   10    |   82.6  |
 | [(Drozdov et al 2022)](https://arxiv.org/abs/2205.01464) PR     | amr3.0-structured-bart-large-neur-al-sampling5-seed42  |   1     |   82.9  |
-| [(Lee et al 2022)](https://arxiv.org/abs/2112.07790) (ensemble) | amr3joint_ontowiki2_g2g-structured-bart-large          |   10    |   85.9  |  
+| [(Lee et al 2022)](https://arxiv.org/abs/2112.07790) (ensemble) | amr2joint_ontowiki2_g2g-structured-bart-large          |   10    |   85.9  |  
 | [(Lee et al 2022)](https://arxiv.org/abs/2112.07790) (ensemble) | amr3joint_ontowiki2_g2g-structured-bart-large          |   10    |   84.4  |  
 
 we also provide the trained `ibm-neural-aligner` under names `AMR2.0_ibm_neural_aligner.zip` and `AMR3.0_ibm_neural_aligner.zip`. For the ensemble we provide the three seeds. Following fairseq conventions, to run the ensemble just give the three checkpoint paths joined by `:` to the normal checkpoint argument `-c`. Note that the checkpoints were trained with the `v0.5.1` tokenizer, this reduces performance by `0.1` on `v0.5.2` tokenized data.


### PR DESCRIPTION
Thank you for releasing your code and checkpoints! It's very helpful. However, there may be a config name typo in the `Trained checkpoints` section in `README.md`

# fix typo

## existing problems

The config is the same for those two lines: 

```
amr3joint_ontowiki2_g2g-structured-bart-large | 10 | 85.9 |
amr3joint_ontowiki2_g2g-structured-bart-large | 10 | 84.4 |
```

## possible fix

Change the word in the first line from `amr3joint` to `amr2joint`, according to your aws bucket and paper. 

```
amr2joint_ontowiki2_g2g-structured-bart-large | 10 | 85.9 |
amr3joint_ontowiki2_g2g-structured-bart-large | 10 | 84.4 |
```

Best wishes!